### PR TITLE
Support for newer pyld

### DIFF
--- a/iiif_prezi/loader.py
+++ b/iiif_prezi/loader.py
@@ -28,13 +28,14 @@ class SerializationError(PresentationError):
     pass
 
 
-def load_document_local(url):
+def load_document_local(url, **options):
     """Load local copy of context document with given url.
 
     Returns dict with three elements 'contextUrl'=None,
     'documentUrl'=None and 'document' set to data read
     """
-    doc = {'contextUrl': None,
+    doc = {'contentType': 'application/json',
+           'contextUrl': None,
            'documentUrl': None,
            'document': ''}
     contexts_dir = os.path.join(os.path.dirname(__file__), 'contexts')


### PR DESCRIPTION
When trying to read an existing manifest, I get errors because pyld expects to be able to send additional options to the custom document loader. Also it expects a contentType key on the returned object. I could take an older version of pyld as well, but this fixes the issues for me.